### PR TITLE
Implement register access mode

### DIFF
--- a/cmake/arm-none-eabi-gcc.cmake
+++ b/cmake/arm-none-eabi-gcc.cmake
@@ -51,6 +51,9 @@ add_compile_options(
     -g3
     -fno-rtti
     -fno-exceptions
+    -Wno-volatile # C++20 deprecated volatile stuff
+    -Wall
+    -Werror
 )
 
 

--- a/cmake/firmware_funcs.cmake
+++ b/cmake/firmware_funcs.cmake
@@ -4,7 +4,8 @@
 #   LINKER_SCRIPT   script for linking the target
 #   SOURCES         source files for the target
 #   INCLUDE_DIRS    include directories
-#   
+#   LINK_TARGETS    link libraries that were created with add_library
+#   LINK_LIBRARIES  link libraries
 function(add_firmware TARGET_NAME)
     set(options)
     set(one_val_options LINKER_SCRIPT)

--- a/include/armpp/hal/registers.hpp
+++ b/include/armpp/hal/registers.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <armpp/util/mask.hpp>
+
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
@@ -31,62 +33,144 @@ using address      = std::uint32_t;
  *
  */
 enum class register_mode { volatile_reg = 0, non_volatile_reg = 1 };
+enum class access_mode { bitwise = 0, register_wise };
 
 namespace detail {
 
-template <concepts::register_value T, std::size_t Offset, std::size_t Size, register_mode Mode>
+template <concepts::register_value T, std::size_t Offset, std::size_t Size, access_mode Access,
+          register_mode Mode>
 struct register_data {
     using value_type           = T;
     raw_register pad_ : Offset = 0;
     value_type volatile value_ : Size;
 
+    constexpr value_type
+    get() const
+    {
+        return value_;
+    }
+
+    void
+    set(value_type value)
+    {
+        value_ = value;
+    }
+
     constexpr register_data() = default;
 };
 
 template <concepts::register_value T, std::size_t Size>
-struct register_data<T, 0, Size, register_mode::volatile_reg> {
+struct register_data<T, 0, Size, access_mode::bitwise, register_mode::volatile_reg> {
     using value_type = T;
     value_type volatile value_ : Size;
+
+    constexpr value_type
+    get() const
+    {
+        return value_;
+    }
+
+    void
+    set(value_type value)
+    {
+        value_ = value;
+    }
 
     constexpr register_data() = default;
 };
 
 template <concepts::register_value T, std::size_t Offset, std::size_t Size>
-struct register_data<T, Offset, Size, register_mode::non_volatile_reg> {
+struct register_data<T, Offset, Size, access_mode::bitwise, register_mode::non_volatile_reg> {
     using value_type           = T;
     raw_register pad_ : Offset = 0;
     value_type   value_ : Size;
+
+    constexpr value_type
+    get() const
+    {
+        return value_;
+    }
+
+    void
+    set(value_type value)
+    {
+        value_ = value;
+    }
 
     constexpr register_data() = default;
 };
 
 template <concepts::register_value T, std::size_t Size>
-struct register_data<T, 0, Size, register_mode::non_volatile_reg> {
+struct register_data<T, 0, Size, access_mode::bitwise, register_mode::non_volatile_reg> {
     using value_type = T;
     value_type value_ : Size;
 
+    constexpr value_type
+    get() const
+    {
+        return value_;
+    }
+
+    void
+    set(value_type value)
+    {
+        value_ = value;
+    }
+
     constexpr register_data() = default;
+};
+
+
+
+template <concepts::register_value T, std::size_t Offset, std::size_t Size>
+struct register_data<T, Offset, Size, access_mode::register_wise, register_mode::volatile_reg> {
+    using value_type           = T;
+    static constexpr auto mask = util::bit_mask_v<Offset, Size, raw_register>;
+
+    constexpr value_type
+    get() const
+    {
+        if constexpr (!std::is_same_v<value_type, raw_register>) {
+            return static_cast<value_type>((register_ & mask) >> Offset);
+        } else {
+            return (register_ & mask) >> Offset;
+        }
+    }
+
+    void
+    set(value_type value)
+    {
+        if constexpr (!std::is_same_v<value_type, raw_register>) {
+            register_ |= (static_cast<raw_register>(value) << Offset) & mask;
+        } else {
+            register_ |= (value << Offset) & mask;
+        }
+    }
+
+    raw_register volatile register_;
 };
 
 }    // namespace detail
 
 template <concepts::register_value T, std::size_t Offset, std::size_t Size,
-          register_mode Mode = register_mode::volatile_reg>
+          access_mode   Access = access_mode::bitwise,
+          register_mode Mode   = register_mode::volatile_reg>
     requires(Offset + Size <= register_bits)
-struct register_base : private detail::register_data<T, Offset, Size, Mode> {
+struct register_base : private detail::register_data<T, Offset, Size, Access, Mode> {
     using value_type = T;
 
     constexpr register_base() = default;
 
+protected:
     constexpr bool
     operator==(register_base const& other) const
     {
-        return value_ == other.value_;
+        return get() == other.get();
     }
     constexpr bool
     operator==(value_type const& other) const
     {
-        return value_ == other;
+        return get() == get();
     }
 
     constexpr bool
@@ -104,15 +188,14 @@ struct register_base : private detail::register_data<T, Offset, Size, Mode> {
     constexpr bool
     operator<(register_base const& other) const
     {
-        return value_ < other.value_;
+        return get() < other.get();
     }
     constexpr bool
     operator<(value_type const& other) const
     {
-        return value_ < other;
+        return get() < other;
     }
 
-protected:
     register_base&
     operator=(register_base const&)
         = delete;
@@ -120,53 +203,45 @@ protected:
     operator=(register_base&&)
         = delete;
 
-    constexpr value_type const
-    get() const
-    {
-        return value_;
-    }
-
-    constexpr operator value_type() const { return value_; }
-
-    void
-    set(T value)
-    {
-        value_ = value;
-    }
-
     register_base&
     operator=(T const& value)
     {
-        value_ = value;
+        set(value);
         return *this;
     }
+
+    constexpr operator value_type() const { return get(); }
+
+    using reg_data_type = detail::register_data<T, Offset, Size, Access, Mode>;
+    using reg_data_type::get;
+    using reg_data_type::set;
 
 private:
     register_base(register_base const&) = delete;
     register_base(register_base&&)      = delete;
-
-    using reg_data_type = detail::register_data<T, Offset, Size, Mode>;
-    using reg_data_type::value_;
 };
 
-template <concepts::register_value T, std::size_t Offset, std::size_t Size>
+template <concepts::register_value T, std::size_t Offset, std::size_t Size, access_mode Access,
+          register_mode Mode>
 constexpr bool
-operator==(T const& rhs, register_base<T, Offset, Size> const& lhs)
+operator==(T const& rhs, register_base<T, Offset, Size, Access, Mode> const& lhs)
 {
     return lhs == rhs;
 }
 
-template <concepts::register_value T, std::size_t Offset, std::size_t Size>
+template <concepts::register_value T, std::size_t Offset, std::size_t Size, access_mode Access,
+          register_mode Mode>
 constexpr bool
-operator<(T const& rhs, register_base<T, Offset, Size> const& lhs)
+operator<(T const& rhs, register_base<T, Offset, Size, Access, Mode> const& lhs)
 {
     return !(lhs < rhs) && (rhs != lhs);
 }
 
 template <concepts::register_value T, std::size_t Offset, std::size_t Size,
-          register_mode Mode = register_mode::volatile_reg>
-struct read_write_register : register_base<T, Offset, Size, Mode> {
-    using base_type  = register_base<T, Offset, Size, Mode>;
+          access_mode   Access = access_mode::bitwise,
+          register_mode Mode   = register_mode::volatile_reg>
+struct read_write_register : register_base<T, Offset, Size, Access, Mode> {
+    using base_type  = register_base<T, Offset, Size, Access, Mode>;
     using value_type = typename base_type::value_type;
 
     using base_type::base_type;
@@ -180,9 +255,10 @@ struct read_write_register : register_base<T, Offset, Size, Mode> {
 };
 
 template <concepts::register_value T, std::size_t Offset, std::size_t Size,
-          register_mode Mode = register_mode::volatile_reg>
-struct read_only_register : register_base<T, Offset, Size, Mode> {
-    using base_type  = register_base<T, Offset, Size, Mode>;
+          access_mode   Access = access_mode::bitwise,
+          register_mode Mode   = register_mode::volatile_reg>
+struct read_only_register : register_base<T, Offset, Size, Access, Mode> {
+    using base_type  = register_base<T, Offset, Size, Access, Mode>;
     using value_type = typename base_type::value_type;
 
     using base_type::base_type;
@@ -194,15 +270,13 @@ struct read_only_register : register_base<T, Offset, Size, Mode> {
 };
 
 template <concepts::register_value T, std::size_t Offset, std::size_t Size,
-          register_mode Mode = register_mode::volatile_reg>
-struct write_only_register : register_base<T, Offset, Size, Mode> {
-    using base_type  = register_base<T, Offset, Size, Mode>;
+          access_mode   Access = access_mode::bitwise,
+          register_mode Mode   = register_mode::volatile_reg>
+struct write_only_register : register_base<T, Offset, Size, Access, Mode> {
+    using base_type  = register_base<T, Offset, Size, Access, Mode>;
     using value_type = typename base_type::value_type;
 
     using base_type::base_type;
-    using base_type::operator==;
-    using base_type::operator!=;
-    using base_type::operator<;
     using base_type::set;
     using base_type::operator=;
 };
@@ -214,28 +288,37 @@ using raw_read_only_register = read_only_register<raw_register, Offset, Size>;
 template <std::size_t Offset, std::size_t Size>
 using raw_write_only_register = write_only_register<raw_register, Offset, Size>;
 
-template <std::size_t Offset, register_mode Mode = register_mode::volatile_reg>
-using bit_read_write_register = read_write_register<raw_register, Offset, 1, Mode>;
-template <std::size_t Offset, register_mode Mode = register_mode::volatile_reg>
-using bit_read_only_register = read_only_register<raw_register, Offset, 1, Mode>;
-template <std::size_t Offset, register_mode Mode = register_mode::volatile_reg>
-using bit_write_only_register = write_only_register<raw_register, Offset, 1, Mode>;
+template <std::size_t Offset, access_mode Access = access_mode::bitwise,
+          register_mode Mode = register_mode::volatile_reg>
+using bit_read_write_register = read_write_register<raw_register, Offset, 1, Access, Mode>;
+template <std::size_t Offset, access_mode Access = access_mode::bitwise,
+          register_mode Mode = register_mode::volatile_reg>
+using bit_read_only_register = read_only_register<raw_register, Offset, 1, Access, Mode>;
+template <std::size_t Offset, access_mode Access = access_mode::bitwise,
+          register_mode Mode = register_mode::volatile_reg>
+using bit_write_only_register = write_only_register<raw_register, Offset, 1, Access, Mode>;
 
-template <std::size_t Offset, register_mode Mode = register_mode::volatile_reg>
-using bool_read_write_register = read_write_register<bool, Offset, 1, Mode>;
-template <std::size_t Offset, register_mode Mode = register_mode::volatile_reg>
-using bool_read_only_register = read_only_register<bool, Offset, 1, Mode>;
-template <std::size_t Offset, register_mode Mode = register_mode::volatile_reg>
-using bool_write_only_register = write_only_register<bool, Offset, 1, Mode>;
+template <std::size_t Offset, access_mode Access = access_mode::bitwise,
+          register_mode Mode = register_mode::volatile_reg>
+using bool_read_write_register = read_write_register<bool, Offset, 1, Access, Mode>;
+template <std::size_t Offset, access_mode Access = access_mode::bitwise,
+          register_mode Mode = register_mode::volatile_reg>
+using bool_read_only_register = read_only_register<bool, Offset, 1, Access, Mode>;
+template <std::size_t Offset, access_mode Access = access_mode::bitwise,
+          register_mode Mode = register_mode::volatile_reg>
+using bool_write_only_register = write_only_register<bool, Offset, 1, Access, Mode>;
 
 //----------------------------------------------------------------------------
 // Traits and concepts
 template <typename T>
 struct is_register_field : std::false_type {};
-template <template <concepts::register_value, std::size_t, std::size_t, register_mode> typename Reg,
-          concepts::register_value T, std::size_t Offset, std::size_t Size, register_mode Mode>
-struct is_register_field<Reg<T, Offset, Size, Mode>>
-    : std::is_base_of<register_base<T, Offset, Size, Mode>, Reg<T, Offset, Size, Mode>> {};
+template <template <concepts::register_value, std::size_t, std::size_t, access_mode, register_mode>
+          typename Reg,
+          concepts::register_value T, std::size_t Offset, std::size_t Size, access_mode Access,
+          register_mode Mode>
+struct is_register_field<Reg<T, Offset, Size, Access, Mode>>
+    : std::is_base_of<register_base<T, Offset, Size, Access, Mode>,
+                      Reg<T, Offset, Size, Access, Mode>> {};
 
 // Traits static test
 static_assert(!is_register_field<std::uint32_t>::value);

--- a/include/armpp/hal/system.hpp
+++ b/include/armpp/hal/system.hpp
@@ -30,7 +30,10 @@ public:
     }
 
     tick_type
-    system_frequency() const;
+    system_frequency() const
+    {
+        return system_frequency_;
+    }
 
 public:
     static clock const&
@@ -45,6 +48,7 @@ private:
     static clock&
     mutable_instance();
 
+    tick_type system_frequency_;
     tick_type tick_;
 };
 

--- a/include/armpp/hal/uart.hpp
+++ b/include/armpp/hal/uart.hpp
@@ -25,13 +25,13 @@ static_assert(sizeof(state_register) == 4);
 template <register_mode Mode = register_mode::volatile_reg>
 union control_register {
     union {
-        bool_read_write_register<0, Mode> tx_enable;
-        bool_read_write_register<1, Mode> rx_enable;
-        bool_read_write_register<2, Mode> tx_interrupt_enable;
-        bool_read_write_register<3, Mode> rx_interrupt_enable;
-        bool_read_write_register<4, Mode> tx_overrun_interrupt_enable;
-        bool_read_write_register<5, Mode> rx_overrun_interrupt_enable;
-        bool_read_write_register<6, Mode> hs_test_mode;
+        bool_read_write_register<0, access_mode::bitwise, Mode> tx_enable;
+        bool_read_write_register<1, access_mode::bitwise, Mode> rx_enable;
+        bool_read_write_register<2, access_mode::bitwise, Mode> tx_interrupt_enable;
+        bool_read_write_register<3, access_mode::bitwise, Mode> rx_interrupt_enable;
+        bool_read_write_register<4, access_mode::bitwise, Mode> tx_overrun_interrupt_enable;
+        bool_read_write_register<5, access_mode::bitwise, Mode> rx_overrun_interrupt_enable;
+        bool_read_write_register<6, access_mode::bitwise, Mode> hs_test_mode;
     };
     raw_register volatile raw;
 
@@ -55,7 +55,7 @@ union interrupt_register {
 };
 static_assert(sizeof(interrupt_register) == 4);
 
-using bauddiv_register = raw_register;    // read_write_register<raw_register, 0, 20>;
+using bauddiv_register = read_write_register<raw_register, 0, 20, access_mode::register_wise>;
 static_assert(sizeof(bauddiv_register) == 4);
 
 // TODO Maybe flags?
@@ -254,8 +254,15 @@ static_assert(sizeof(uart) == 4 * 5);
  */
 class uart_handle {
 public:
+    uart_handle(address device_address) : device_(*reinterpret_cast<uart*>(device_address)) {}
     uart_handle(address device_address, uart_init const& init) noexcept
-        : device_(*reinterpret_cast<uart*>(device_address))
+        : uart_handle{device_address}
+    {
+        configure(init);
+    }
+
+    void
+    configure(uart_init const& init) noexcept
     {
         // TODO check for error status and report it somehow
         device_.configure(init);

--- a/include/armpp/util/mask.hpp
+++ b/include/armpp/util/mask.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <concepts>
+#include <cstdint>
+
+namespace armpp::util {
+
+template <std::size_t Length, std::unsigned_integral T = std::uint32_t>
+    requires(Length <= sizeof(T) * 8)
+struct bit_sequence {
+    static constexpr T value = (bit_sequence<Length - 1, T>::value << 1) | 1;
+};
+
+template <std::unsigned_integral T>
+struct bit_sequence<1, T> {
+    static constexpr T value = 1;
+};
+
+template <std::size_t Length, std::unsigned_integral T = std::uint32_t>
+constexpr T bit_sequence_v = bit_sequence<Length, T>::value;
+
+static_assert(bit_sequence_v<1> == 0b1);
+static_assert(bit_sequence_v<3> == 0b111);
+
+template <std::size_t Offset, std::size_t Length, std::unsigned_integral T = std::uint32_t>
+    requires(Length + Offset <= sizeof(T) * 8)
+struct bit_mask {
+    static constexpr T value = bit_sequence_v<Length, T> << Offset;
+};
+
+template <std::size_t Offset, std::size_t Length, std::unsigned_integral T = std::uint32_t>
+constexpr T bit_mask_v = bit_mask<Offset, Length, T>::value;
+
+static_assert(bit_mask_v<0, 2> == 0b11);
+static_assert(bit_mask_v<3, 5> == 0b11111000);
+
+}    // namespace armpp::util

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -4,12 +4,16 @@ void
 system_init()
 {
     // init clocks here
+    using namespace armpp::hal::system;
+    // TODO Move the magic constant somewhere
+    clock::mutable_instance().system_frequency_ = 54'000'000;    // 54MHz
 }
 
 void
 system_tick()
 {
-    armpp::hal::system::clock::mutable_instance().increment_tick();
+    using namespace armpp::hal::system;
+    clock::mutable_instance().increment_tick();
 }
 
 namespace armpp::hal::system {

--- a/src/uart.cpp
+++ b/src/uart.cpp
@@ -1,6 +1,6 @@
 #include <armpp/hal/uart.hpp>
-
-extern "C" uint32_t PCLK1;
+//
+#include <armpp/hal/system.hpp>
 
 namespace armpp::hal::uart {
 void
@@ -24,7 +24,7 @@ uart::configure(uart_init const& init)
 
     ctrl_.raw = 0;
     ctrl_.raw = new_ctrl.raw;
-    // TODO replace with clock control
-    bauddiv_ = PCLK1 / init.baud_rate;
+    // TODO replace with required clock control
+    bauddiv_ = system::clock::instance().system_frequency() / init.baud_rate;
 }
 }    // namespace armpp::hal::uart


### PR DESCRIPTION
Add an option to access underlying register as std::uint32_t as some registers don't allow bitwise access